### PR TITLE
Correction of the update of an apply form view

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install maestro
-        run: uv pip install maestro@git+https://github.com/ehmoussi/maestro.git
+        run: uv add maestro@git+https://github.com/ehmoussi/maestro.git
       - name: Install composeui
         run: uv sync --extra dev --extra all
       - name: Install composeui

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install maestro
-        run: uv install maestro@git+https://github.com/ehmoussi/maestro.git
+        run: uv pip install maestro@git+https://github.com/ehmoussi/maestro.git
       - name: Install composeui
         run: uv sync --extra dev --extra all
       - name: Install composeui

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,11 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Set up Python
         run: uv python install
-      - name: Install
-        run: uv sync --extra dev_maestro --extra all
+      - name: Install maestro
+        run: uv install maestro@git+https://github.com/ehmoussi/maestro.git
+      - name: Install composeui
+        run: uv sync --extra dev --extra all
+      - name: Install composeui
+        run: uv sync --extra dev --extra all
       - name: Run  ${{ matrix.cmd }}
         run: uv run maestro  ${{ matrix.cmd }}  ${{ matrix.args }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install maestro
-        run: uv pip install maestro@git+https://github.com/ehmoussi/maestro.git
+        run: uv add maestro@git+https://github.com/ehmoussi/maestro.git
       - name: Install composeui
         run: uv sync --extra dev --extra all
       - name: Run the tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
           cache-dependency-glob: "uv.lock"
       - name: Set up Python
         run: uv python install
-      - name: Install
-        run: uv sync --extra dev_maestro --extra all
+      - name: Install maestro
+        run: uv install maestro@git+https://github.com/ehmoussi/maestro.git
+      - name: Install composeui
+        run: uv sync --extra dev --extra all
       - name: Run the tests
         run: xvfb-run --auto-servernum uv run maestro test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Install maestro
-        run: uv install maestro@git+https://github.com/ehmoussi/maestro.git
+        run: uv pip install maestro@git+https://github.com/ehmoussi/maestro.git
       - name: Install composeui
         run: uv sync --extra dev --extra all
       - name: Run the tests

--- a/.github/workflows/tests_py36.yml
+++ b/.github/workflows/tests_py36.yml
@@ -16,7 +16,9 @@ jobs:
         with:
           python-version: "3.6"
           cache: "pip"
-      - name: Install
-        run: python -m pip install -e .[dev_maestro,all]
+      - name: Install maestro
+        run: python -m pip install maestro@git+https://github.com/ehmoussi/maestro.git
+      - name: Install composeui
+        run: python -m pip install -e .[dev,all]
       - name: Run the tests
         run: xvfb-run --auto-servernum maestro test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,15 +85,6 @@ dev = [
     "types-aiofiles",
     "pytest-asyncio",
 ]
-dev_maestro = [
-    "maestro@git+https://github.com/ehmoussi/maestro.git",
-    "pandas_stubs",
-    "PyQt5-stubs",
-    "types-markdown",
-    "types-openpyxl",
-    "types-aiofiles",
-    "pytest-asyncio",
-]
 
 [tool.setuptools_scm]
 

--- a/src/composeui/apps/eventdrivenappmixin.py
+++ b/src/composeui/apps/eventdrivenappmixin.py
@@ -37,12 +37,20 @@ class EventDrivenAppMixin(ABC, Generic[AnyMainView, AnyModel]):
     def connect(self) -> None:
         assert self._main_view is not None
         assert self._model is not None
-        connect_by_default(self._main_view, self._main_view, self._model)
+        connect_by_default(self._main_view, self._main_view, self)
         self.connect_app()
 
     def disconnect(self) -> None:
         assert self._main_view is not None
         disconnect.disconnect(self._main_view)
+
+    def new_study(self) -> None:
+        assert self._main_view is not None
+        assert self._model is not None
+        self._model.new()
+        self.disconnect()
+        self.initialize()
+        self.connect()
 
     @staticmethod
     def _add_app_to_base_signal(main_view: View, model: BaseModel) -> None:

--- a/src/composeui/apps/eventdrivenappmixin.py
+++ b/src/composeui/apps/eventdrivenappmixin.py
@@ -30,14 +30,14 @@ class EventDrivenAppMixin(ABC, Generic[AnyMainView, AnyModel]):
     def initialize(self) -> None:
         assert self._main_view is not None
         assert self._model is not None
-        self._add_app_to_base_signal(self._main_view, self._model)
+        self._add_app_to_base_signal(self._main_view, self._model, self)
         initialize_default_view(self._main_view)
         self.initialize_app()
 
     def connect(self) -> None:
         assert self._main_view is not None
         assert self._model is not None
-        connect_by_default(self._main_view, self._main_view, self)
+        connect_by_default(self._main_view, self._main_view)
         self.connect_app()
 
     def disconnect(self) -> None:
@@ -53,7 +53,9 @@ class EventDrivenAppMixin(ABC, Generic[AnyMainView, AnyModel]):
         self.connect()
 
     @staticmethod
-    def _add_app_to_base_signal(main_view: View, model: BaseModel) -> None:
+    def _add_app_to_base_signal(
+        main_view: View, model: BaseModel, app: "EventDrivenAppMixin[AnyMainView, AnyModel]"
+    ) -> None:
         views: deque[  # type:ignore[type-arg]
             Tuple[Optional[FormView], Optional[View], View]
         ] = deque()
@@ -80,6 +82,7 @@ class EventDrivenAppMixin(ABC, Generic[AnyMainView, AnyModel]):
                     current_field.current_view = weakref.ref(current_view)
                     current_field.main_view = weakref.ref(main_view)
                     current_field.model = weakref.ref(model)
+                    current_field.event_driven_app = weakref.ref(app)
                 elif isinstance(current_field, View):
                     if isinstance(current_field, RowItemView) and isinstance(
                         current_parent_view, FormView

--- a/src/composeui/apps/qtbaseapp.py
+++ b/src/composeui/apps/qtbaseapp.py
@@ -38,9 +38,9 @@ class QtBaseApp(BaseApp, EventDrivenAppMixin[AnyMainView, AnyModel]):
     def model(self) -> AnyModel:
         return self._model
 
-    def run(self) -> None:
+    def run(self, log_signals: bool = False) -> None:
         super().run()
-        if self._args is not None and self._args.log_signals:
+        if log_signals or (self._args is not None and self._args.log_signals):
             SIGNAL_LOGGER.setLevel(level=logging.DEBUG)
         self.initialize()
         self.connect()

--- a/src/composeui/core/basesignal.py
+++ b/src/composeui/core/basesignal.py
@@ -44,6 +44,7 @@ P = ParamSpec("P")
 
 if typing.TYPE_CHECKING:
     from qtpy.QtCore import QObject, SignalInstance  # type: ignore[attr-defined]
+    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
 
 
 SIGNAL_LOGGER = logging.getLogger("SIGNAL")
@@ -229,6 +230,9 @@ class BaseSignal(MutableSequence[Callback]):
         )
         self.main_view: Optional[ReferenceType[View]] = None
         self.model: Optional[ReferenceType[BaseModel]] = None
+        self.event_driven_app: Optional[
+            ReferenceType[EventDrivenAppMixin[View, BaseModel]]
+        ] = None
 
     def _signal_log(self, callback: Callback, *args: Any, **kwargs: Any) -> None:
         if callable(callback):
@@ -418,6 +422,7 @@ class BaseSignal(MutableSequence[Callback]):
                 "form_view": self.current_form_view,
                 "main_view": self.main_view,
                 "model": self.model,
+                "app": self.event_driven_app,
             }
             kwargs = {}
             index_positional_arg = 0

--- a/src/composeui/core/basesignal.py
+++ b/src/composeui/core/basesignal.py
@@ -11,6 +11,7 @@ if typing.TYPE_CHECKING:
     from composeui.model.basemodel import BaseModel
     from composeui.form.formview import FormView
     from composeui.core.views.view import View
+    from composeui.mainview.views.mainview import MainView
 
 from typing_extensions import ParamSpec, TypeAlias
 
@@ -43,8 +44,9 @@ else:
 P = ParamSpec("P")
 
 if typing.TYPE_CHECKING:
-    from qtpy.QtCore import QObject, SignalInstance  # type: ignore[attr-defined]
     from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
+
+    from qtpy.QtCore import QObject, SignalInstance  # type: ignore[attr-defined]
 
 
 SIGNAL_LOGGER = logging.getLogger("SIGNAL")
@@ -231,7 +233,7 @@ class BaseSignal(MutableSequence[Callback]):
         self.main_view: Optional[ReferenceType[View]] = None
         self.model: Optional[ReferenceType[BaseModel]] = None
         self.event_driven_app: Optional[
-            ReferenceType[EventDrivenAppMixin[View, BaseModel]]
+            ReferenceType[EventDrivenAppMixin[MainView, BaseModel]]
         ] = None
 
     def _signal_log(self, callback: Callback, *args: Any, **kwargs: Any) -> None:

--- a/src/composeui/core/connect.py
+++ b/src/composeui/core/connect.py
@@ -1,6 +1,6 @@
 r"""Connect the signals to the default slots."""
 
-from composeui.commontypes import AnyModel
+from composeui.commontypes import AnyModel, AnyMainView
 from composeui.core import selectfiles
 from composeui.core.tasks import progresstask
 from composeui.core.tasks.abstracttask import AbstractTask
@@ -32,7 +32,10 @@ from composeui.vtk.vtkview import VTKView
 from typing_extensions import Concatenate, ParamSpec
 
 from functools import wraps
-from typing import Callable, Optional, TypeVar
+from typing import Callable, TypeVar, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
 
 Ttask = TypeVar("Ttask", bound=AbstractTask)
 
@@ -59,8 +62,7 @@ def connect_explorer(
 def connect_by_default(
     view: View,
     main_view: MainView,
-    model: AnyModel,
-    parent_view: Optional[View] = None,
+    app: "EventDrivenAppMixin[AnyMainView, AnyModel]",
 ) -> bool:
     r"""Apply default connections to the view.
 
@@ -69,7 +71,7 @@ def connect_by_default(
     if isinstance(view, MainView):
         return connect_main_view(view)
     elif isinstance(view, (FileMenu, FileToolBar)):
-        connect_file_menu_toolbar(view, main_view)
+        connect_file_menu_toolbar(view, main_view, app)
         if isinstance(view, FileMenu):
             connect_file_menu(view)
         return False

--- a/src/composeui/core/connect.py
+++ b/src/composeui/core/connect.py
@@ -1,6 +1,5 @@
 r"""Connect the signals to the default slots."""
 
-from composeui.commontypes import AnyModel, AnyMainView
 from composeui.core import selectfiles
 from composeui.core.tasks import progresstask
 from composeui.core.tasks.abstracttask import AbstractTask
@@ -33,7 +32,6 @@ from typing_extensions import Concatenate, ParamSpec
 
 from functools import wraps
 from typing import Callable, TypeVar
-
 
 Ttask = TypeVar("Ttask", bound=AbstractTask)
 

--- a/src/composeui/core/connect.py
+++ b/src/composeui/core/connect.py
@@ -32,10 +32,8 @@ from composeui.vtk.vtkview import VTKView
 from typing_extensions import Concatenate, ParamSpec
 
 from functools import wraps
-from typing import Callable, TypeVar, TYPE_CHECKING
+from typing import Callable, TypeVar
 
-if TYPE_CHECKING:
-    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
 
 Ttask = TypeVar("Ttask", bound=AbstractTask)
 
@@ -59,11 +57,7 @@ def connect_explorer(
 
 
 @connect_explorer
-def connect_by_default(
-    view: View,
-    main_view: MainView,
-    app: "EventDrivenAppMixin[AnyMainView, AnyModel]",
-) -> bool:
+def connect_by_default(view: View, main_view: MainView) -> bool:
     r"""Apply default connections to the view.
 
     Returns True if it needs to explore also its children.
@@ -71,7 +65,7 @@ def connect_by_default(
     if isinstance(view, MainView):
         return connect_main_view(view)
     elif isinstance(view, (FileMenu, FileToolBar)):
-        connect_file_menu_toolbar(view, main_view, app)
+        connect_file_menu_toolbar(view, main_view)
         if isinstance(view, FileMenu):
             connect_file_menu(view)
         return False

--- a/src/composeui/core/initialize.py
+++ b/src/composeui/core/initialize.py
@@ -9,6 +9,8 @@ from composeui.core.views.selectpathview import SelectPathView
 from composeui.core.views.view import GroupView, View
 from composeui.figure import initialize_figure_view
 from composeui.figure.figureview import FigureView
+from composeui.form import initialize_form_view
+from composeui.form.formview import FormView
 from composeui.items.core.initialize import initialize_items_view
 from composeui.items.linkedtable import initialize_linked_table
 from composeui.items.linkedtable.linkedtableview import LinkedTableView
@@ -77,6 +79,8 @@ def initialize_default_view(view: View) -> bool:
         return initialize_tree_view(view)
     elif isinstance(view, TableView):
         return initialize_items_view(view)
+    elif isinstance(view, FormView):
+        return initialize_form_view(view)
     elif isinstance(view, SelectPathView):
         return initialize_select_path_view(view)
     elif isinstance(view, PopupTextView):

--- a/src/composeui/core/initialize.py
+++ b/src/composeui/core/initialize.py
@@ -9,8 +9,6 @@ from composeui.core.views.selectpathview import SelectPathView
 from composeui.core.views.view import GroupView, View
 from composeui.figure import initialize_figure_view
 from composeui.figure.figureview import FigureView
-from composeui.form import initialize_form_view
-from composeui.form.formview import FormView
 from composeui.items.core.initialize import initialize_items_view
 from composeui.items.linkedtable import initialize_linked_table
 from composeui.items.linkedtable.linkedtableview import LinkedTableView
@@ -79,8 +77,6 @@ def initialize_default_view(view: View) -> bool:
         return initialize_tree_view(view)
     elif isinstance(view, TableView):
         return initialize_items_view(view)
-    elif isinstance(view, FormView):
-        return initialize_form_view(view)
     elif isinstance(view, SelectPathView):
         return initialize_select_path_view(view)
     elif isinstance(view, PopupTextView):

--- a/src/composeui/core/study.py
+++ b/src/composeui/core/study.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
 
 
-def new(app: "EventDrivenAppMixin[AnyMainView, AnyModel]", *, main_view: MainView) -> None:
+def new(*, main_view: MainView, app: "EventDrivenAppMixin[AnyMainView, AnyModel]") -> None:
     r"""Create a new study after asking a confirmation."""
     if ask_confirmation(main_view, "clear"):
         app.new_study()

--- a/src/composeui/core/study.py
+++ b/src/composeui/core/study.py
@@ -1,6 +1,6 @@
 r"""Slots of the study management."""
 
-from composeui.commontypes import AnyModel
+from composeui.commontypes import AnyModel, AnyMainView
 from composeui.core import selectfiles, tools
 from composeui.core.tasks.tasks import Tasks
 from composeui.mainview import progresspopup
@@ -11,10 +11,16 @@ from functools import partial
 from pathlib import Path
 
 
-def new(*, main_view: MainView, model: AnyModel) -> None:
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
+
+
+def new(app: "EventDrivenAppMixin[AnyMainView, AnyModel]", *, main_view: MainView) -> None:
     r"""Create a new study after asking a confirmation."""
     if ask_confirmation(main_view, "clear"):
-        clear(main_view, model)
+        app.new_study()
 
 
 def open_file(*, main_view: MainView, model: AnyModel) -> None:

--- a/src/composeui/core/study.py
+++ b/src/composeui/core/study.py
@@ -1,6 +1,6 @@
 r"""Slots of the study management."""
 
-from composeui.commontypes import AnyModel, AnyMainView
+from composeui.commontypes import AnyMainView, AnyModel
 from composeui.core import selectfiles, tools
 from composeui.core.tasks.tasks import Tasks
 from composeui.mainview import progresspopup
@@ -9,8 +9,6 @@ from composeui.mainview.views.mainview import MainView
 
 from functools import partial
 from pathlib import Path
-
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/src/composeui/core/tasks/progresstask.py
+++ b/src/composeui/core/tasks/progresstask.py
@@ -59,14 +59,3 @@ def check(*, view: ProgressView[T], main_view: MainView) -> None:
             tools.display_error_message(main_view, tasks.join_error_messages())
         elif tasks.status == TaskStatus.WARNING:
             tools.display_warning_message(main_view, tasks.join_warning_messages())
-
-
-# def notify_task_errors(main_view: IProgressView[T], view_path: Tuple[str, ...]) -> None:
-#     r"""Notify the error message of the task."""
-#     view = tools.find_view(main_view, view_path)
-#     warning_message = view["task"].warning_message
-#     if warning_message != "":
-#         tools.display_warning_message(main_view, warning_message)
-#     error_message = view["task"].error_message
-#     if error_message != "":
-#         tools.display_error_message(main_view, error_message)

--- a/src/composeui/core/tools.py
+++ b/src/composeui/core/tools.py
@@ -1,5 +1,6 @@
 r"""Common tools."""
 
+from composeui.form import form
 from composeui.core.views.view import View
 from composeui.form.formview import FormView, RowView
 from composeui.items.table.tableview import TableView
@@ -21,7 +22,7 @@ def update_all_views(main_view: MainView) -> None:
     while len(views) > 0:
         view = views.pop()
         views.extendleft(view.children.values())
-        _update_view(view)
+        _update_view(view, update_visibility=False)
 
 
 def update_view_with_dependencies(
@@ -40,7 +41,10 @@ def update_view_with_dependencies(
 
 
 def _update_view(
-    view: View, keep_selection: bool = False, before_validation: bool = False
+    view: View,
+    keep_selection: bool = False,
+    before_validation: bool = False,
+    update_visibility: bool = True,
 ) -> None:
     r"""Update the given view.
 
@@ -58,12 +62,15 @@ def _update_view(
         elif isinstance(view, FormView) and view.items is not None:
             if not before_validation:
                 view.update()
-            view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            if update_visibility:
+                view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
             view.is_enabled = view.items.is_enabled(view.field_name, view.parent_fields)
+            form.update_infos(view)
         elif isinstance(view, RowView) and view.items is not None:
             if not before_validation:
                 view.update()
-            view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            if update_visibility:
+                view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
             view.field_view.is_enabled = view.items.is_enabled(
                 view.field_name, view.parent_fields
             )

--- a/src/composeui/core/tools.py
+++ b/src/composeui/core/tools.py
@@ -22,7 +22,7 @@ def update_all_views(main_view: MainView) -> None:
     while len(views) > 0:
         view = views.pop()
         views.extendleft(view.children.values())
-        _update_view(view, update_visibility=False)
+        _update_view(view)
 
 
 def update_view_with_dependencies(
@@ -33,7 +33,9 @@ def update_view_with_dependencies(
     updated_dependencies: Set[View] = set()
     while len(dependencies) > 0:
         dependent_view = dependencies.popleft()
-        _update_view(dependent_view, keep_selection, before_validation)
+        _update_view(
+            dependent_view, keep_selection=keep_selection, before_validation=before_validation
+        )
         updated_dependencies.add(dependent_view)
         for dependent_child_view in dependent_view.dependencies:
             if dependent_child_view not in updated_dependencies:
@@ -44,7 +46,6 @@ def _update_view(
     view: View,
     keep_selection: bool = False,
     before_validation: bool = False,
-    update_visibility: bool = True,
 ) -> None:
     r"""Update the given view.
 
@@ -62,15 +63,15 @@ def _update_view(
         elif isinstance(view, FormView) and view.items is not None:
             if not before_validation:
                 view.update()
-            if update_visibility:
-                view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            view.is_visible = is_visible
             view.is_enabled = view.items.is_enabled(view.field_name, view.parent_fields)
             form.update_infos(view)
         elif isinstance(view, RowView) and view.items is not None:
             if not before_validation:
                 view.update()
-            if update_visibility:
-                view.is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            is_visible = view.items.is_visible(view.field_name, view.parent_fields)
+            view.is_visible = is_visible
             view.field_view.is_enabled = view.items.is_enabled(
                 view.field_name, view.parent_fields
             )

--- a/src/composeui/core/tools.py
+++ b/src/composeui/core/tools.py
@@ -1,7 +1,7 @@
 r"""Common tools."""
 
-from composeui.form import form
 from composeui.core.views.view import View
+from composeui.form import form
 from composeui.form.formview import FormView, RowView
 from composeui.items.table.tableview import TableView
 from composeui.mainview.views.fileview import FileView

--- a/src/composeui/core/tools.py
+++ b/src/composeui/core/tools.py
@@ -22,7 +22,7 @@ def update_all_views(main_view: MainView) -> None:
     while len(views) > 0:
         view = views.pop()
         views.extendleft(view.children.values())
-        _update_view(view)
+        _update_view(view, update_visibility=False)
 
 
 def update_view_with_dependencies(
@@ -46,6 +46,7 @@ def _update_view(
     view: View,
     keep_selection: bool = False,
     before_validation: bool = False,
+    update_visibility: bool = True,
 ) -> None:
     r"""Update the given view.
 
@@ -64,14 +65,16 @@ def _update_view(
             if not before_validation:
                 view.update()
             is_visible = view.items.is_visible(view.field_name, view.parent_fields)
-            view.is_visible = is_visible
+            if update_visibility:
+                view.is_visible = is_visible
             view.is_enabled = view.items.is_enabled(view.field_name, view.parent_fields)
             form.update_infos(view)
         elif isinstance(view, RowView) and view.items is not None:
             if not before_validation:
                 view.update()
             is_visible = view.items.is_visible(view.field_name, view.parent_fields)
-            view.is_visible = is_visible
+            if update_visibility:
+                view.is_visible = is_visible
             view.field_view.is_enabled = view.items.is_enabled(
                 view.field_name, view.parent_fields
             )

--- a/src/composeui/core/tools.py
+++ b/src/composeui/core/tools.py
@@ -13,16 +13,6 @@ from collections import deque
 from typing import List, Optional, Set, Tuple
 
 
-def find_view(view: View, view_path: Tuple[str, ...]) -> View:
-    r"""Find the view at the given path."""
-    current_view_path = deque(view_path)
-    current_view = view
-    while len(current_view_path) > 0:
-        child_name = current_view_path.popleft()
-        current_view = getattr(current_view, child_name)
-    return current_view
-
-
 def update_all_views(main_view: MainView) -> None:
     r"""Update all the views."""
     # call the slots associated with the update all signal
@@ -47,20 +37,6 @@ def update_view_with_dependencies(
         for dependent_child_view in dependent_view.dependencies:
             if dependent_child_view not in updated_dependencies:
                 dependencies.append(dependent_child_view)
-
-
-# def update_tables_views(
-#     main_view: IMainView, view_path: Tuple[str, ...], keep_selection=False
-# ) -> None:
-#     r"""Update the table and related tables views."""
-#     view = find_view(main_view, view_path)
-#     _update_view(view, keep_selection)
-#     table_dependencies = main_view.table_dependencies
-#     for dependant_view_path in table_dependencies.get(view_path, []):
-#         dependant_view = find_view(main_view, dependant_view_path)
-#         if isinstance(view, ISelectItemModifyDatasView) and dependant_view is view.selection:
-#             disable_datas_table(view, main_view)
-#         update_tables_views(main_view, dependant_view_path)
 
 
 def _update_view(

--- a/src/composeui/form/__init__.py
+++ b/src/composeui/form/__init__.py
@@ -22,8 +22,14 @@ from functools import partial
 from typing import Optional
 
 
-def initialize_form_view(view: FormView[AnyFormItems], form_items: AnyFormItems) -> None:
+def initialize_form_view(view: FormView[AnyFormItems]) -> bool:
     """Initialize the form view."""
+    form.update_infos(view)
+    return False
+
+
+def initialize_form_view_items(view: FormView[AnyFormItems], form_items: AnyFormItems) -> None:
+    """Initialize the form view items."""
     view.items = form_items
     if view.field_name == "":
         parent_fields = view.parent_fields
@@ -64,7 +70,7 @@ def initialize_form_view(view: FormView[AnyFormItems], form_items: AnyFormItems)
                 else:
                     child_view.field_view.values = OrderedDict()
         elif isinstance(child_view, FormView):
-            initialize_form_view(child_view, form_items)
+            initialize_form_view_items(child_view, form_items)
     tools.update_view_with_dependencies(view)
     form.update_infos(view, with_color=False)
 

--- a/src/composeui/form/__init__.py
+++ b/src/composeui/form/__init__.py
@@ -63,6 +63,7 @@ def initialize_form_view_items(view: FormView[AnyFormItems], form_items: AnyForm
                     child_view.field_view.values = OrderedDict(zip(values, displayed_values))
                 else:
                     child_view.field_view.values = OrderedDict()
+                child_view.field_view.current_index = 0
         elif isinstance(child_view, FormView):
             initialize_form_view_items(child_view, form_items)
     tools.update_view_with_dependencies(view)

--- a/src/composeui/form/__init__.py
+++ b/src/composeui/form/__init__.py
@@ -22,12 +22,6 @@ from functools import partial
 from typing import Optional
 
 
-def initialize_form_view(view: FormView[AnyFormItems]) -> bool:
-    """Initialize the form view."""
-    form.update_infos(view)
-    return False
-
-
 def initialize_form_view_items(view: FormView[AnyFormItems], form_items: AnyFormItems) -> None:
     """Initialize the form view items."""
     view.items = form_items

--- a/src/composeui/form/__init__.py
+++ b/src/composeui/form/__init__.py
@@ -72,7 +72,7 @@ def initialize_form_view_items(view: FormView[AnyFormItems], form_items: AnyForm
         elif isinstance(child_view, FormView):
             initialize_form_view_items(child_view, form_items)
     tools.update_view_with_dependencies(view)
-    form.update_infos(view, with_color=False)
+    form.update_infos(view, with_color=True)
 
 
 def connect_form_view(

--- a/src/composeui/mainview/__init__.py
+++ b/src/composeui/mainview/__init__.py
@@ -1,4 +1,3 @@
-from functools import partial
 from composeui.core import study
 from composeui.core.tasks import progresstask
 from composeui.mainview import toolbar
@@ -10,11 +9,7 @@ from composeui.mainview.views.progresspopupview import ProgressPopupView
 from composeui.mainview.views.toolbar import CheckableToolBar, FileToolBar
 from composeui.salomewrapper.mainview.salomemainview import SalomeMainView
 
-from typing import Union, TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
-    from composeui.commontypes import AnyMainView, AnyModel
+from typing import Union
 
 
 def initialize_main_view(view: MainView) -> bool:
@@ -110,10 +105,9 @@ def connect_file_menu(view: FileMenu) -> bool:
 def connect_file_menu_toolbar(
     view: Union[FileMenu, FileToolBar],
     main_view: MainView,
-    app: "EventDrivenAppMixin[AnyMainView, AnyModel]",
 ) -> bool:
     r"""Connect the signals of the identical menu/toolbar actions."""
-    view.new.triggered = [partial(study.new, app)]
+    view.new.triggered = [study.new]
     if isinstance(main_view, SalomeMainView):
         view.open_file.triggered = [study.open_file_without_update]
     else:

--- a/src/composeui/mainview/__init__.py
+++ b/src/composeui/mainview/__init__.py
@@ -1,3 +1,4 @@
+from functools import partial
 from composeui.core import study
 from composeui.core.tasks import progresstask
 from composeui.mainview import toolbar
@@ -9,7 +10,11 @@ from composeui.mainview.views.progresspopupview import ProgressPopupView
 from composeui.mainview.views.toolbar import CheckableToolBar, FileToolBar
 from composeui.salomewrapper.mainview.salomemainview import SalomeMainView
 
-from typing import Union
+from typing import Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from composeui.apps.eventdrivenappmixin import EventDrivenAppMixin
+    from composeui.commontypes import AnyMainView, AnyModel
 
 
 def initialize_main_view(view: MainView) -> bool:
@@ -102,9 +107,13 @@ def connect_file_menu(view: FileMenu) -> bool:
     return False
 
 
-def connect_file_menu_toolbar(view: Union[FileMenu, FileToolBar], main_view: MainView) -> bool:
+def connect_file_menu_toolbar(
+    view: Union[FileMenu, FileToolBar],
+    main_view: MainView,
+    app: "EventDrivenAppMixin[AnyMainView, AnyModel]",
+) -> bool:
     r"""Connect the signals of the identical menu/toolbar actions."""
-    view.new.triggered = [study.new]
+    view.new.triggered = [partial(study.new, app)]
     if isinstance(main_view, SalomeMainView):
         view.open_file.triggered = [study.open_file_without_update]
     else:

--- a/src/composeui/store/sqlitestore.py
+++ b/src/composeui/store/sqlitestore.py
@@ -1,5 +1,6 @@
 """Data managing state using sqlite."""
 
+import warnings
 from composeui.store.abstractstore import AbstractStore
 
 import contextlib
@@ -81,6 +82,17 @@ class SqliteStore(AbstractStore):
                 self.create_pool()
                 with self.get_connection() as db_conn:
                     filepath_con.backup(db_conn)
+        try:
+            self.create_tables()
+        except Exception as e:  # noqa: BLE001
+            warnings.warn(
+                (
+                    f"Failed to execute the sql files because of '{e.args[0]}'. "
+                    "Hint: The definition of tables and triggers "
+                    "should always have 'IF NOT EXISTS'."
+                ),
+                stacklevel=2,
+            )
 
     def create_pool(self) -> None:
         self.close_pool()

--- a/src/composeui/store/sqlitestore.py
+++ b/src/composeui/store/sqlitestore.py
@@ -1,6 +1,5 @@
 """Data managing state using sqlite."""
 
-import warnings
 from composeui.store.abstractstore import AbstractStore
 
 import contextlib
@@ -9,6 +8,7 @@ import queue
 import sqlite3
 import sys
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Generator, List, Optional, Sequence
 

--- a/src/examples/asyncview/filereader.py
+++ b/src/examples/asyncview/filereader.py
@@ -76,7 +76,7 @@ class FileReaderView(GroupBoxApplyFormView[FileReaderItems]):
 
 
 def initialize_file_reader(*, view: FileReaderView, model: "Model") -> None:
-    form.initialize_form_view(view, FileReaderItems(model, view))
+    form.initialize_form_view_items(view, FileReaderItems(model, view))
     view.title = "File Reader"
     view.content.field_view.is_read_only = True
     view.output_filepath.field_view.mode = "save_file"

--- a/src/examples/formview/app.py
+++ b/src/examples/formview/app.py
@@ -22,9 +22,7 @@ class FormViewApp(QtBaseApp[ExampleMainView, Model]):
 
     def initialize_app(self) -> None:
         initialize_navigation(self.main_view.toolbar.navigation, self.main_view, self.model)
-        pipeform.initialize_pipe(
-            self.main_view.pipe_view, self.main_view, self.model, is_visible=True
-        )
+        pipeform.initialize_pipe(self.main_view.pipe_view, self.model, is_visible=True)
         pipeapplyform.initialize_apply_pipe(self.main_view.apply_pipe_view, self.model)
 
     def connect_app(self) -> None: ...  # no connections

--- a/src/examples/formview/pipeapplyform.py
+++ b/src/examples/formview/pipeapplyform.py
@@ -55,7 +55,7 @@ def initialize_apply_pipe(
     model: "Model",
     is_visible: bool = False,
 ) -> None:
-    form.initialize_form_view(view, PipeApplyFormItems(model, view))
+    form.initialize_form_view_items(view, PipeApplyFormItems(model, view))
     view.is_visible = is_visible
     view.title = "Pipe"
     view.export.field_view.mode = "save_file"

--- a/src/examples/formview/pipeform.py
+++ b/src/examples/formview/pipeform.py
@@ -18,7 +18,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Ty
 
 if TYPE_CHECKING:
     from examples.formview.app import Model
-    from examples.formview.example import ExampleMainView
 
 
 class EdgeType(Enum):
@@ -93,7 +92,6 @@ class PipeFormView(GroupBoxFormView["PipeFormItems"]):
 
 def initialize_pipe(
     view: PipeFormView,
-    main_view: "ExampleMainView",
     model: "Model",
     is_visible: bool = False,
 ) -> None:

--- a/src/examples/formview/pipeform.py
+++ b/src/examples/formview/pipeform.py
@@ -97,7 +97,7 @@ def initialize_pipe(
     model: "Model",
     is_visible: bool = False,
 ) -> None:
-    form.initialize_form_view(view, PipeFormItems(model, view))
+    form.initialize_form_view_items(view, PipeFormItems(model, view))
     view.is_visible = is_visible
     view.title = "Pipe"
     view.export.field_view.mode = "save_file"

--- a/src/examples/salomeview/cubedefinition.py
+++ b/src/examples/salomeview/cubedefinition.py
@@ -345,7 +345,7 @@ def build_cube_geometry(
 
 
 def initialize_cube_definition(view: CubeDefinitionView, model: "Model") -> None:
-    form.initialize_form_view(view, CubeDefinitionItems(model, view))
+    form.initialize_form_view_items(view, CubeDefinitionItems(model, view))
     view.cube.field_view.dependencies.append(view.parameters)
 
 

--- a/src/examples/taskview/mashumaro/task.py
+++ b/src/examples/taskview/mashumaro/task.py
@@ -112,7 +112,7 @@ def update_task_status(*, view: ProgressView["Task"], parent_view: "TaskView") -
 
 def initialize_task(view: TaskView, main_view: "ExampleMainView", model: "Model") -> None:
     view.config.title = "Configuration"
-    form.initialize_form_view(view.config, TaskConfigItems(model, view.config))
+    form.initialize_form_view_items(view.config, TaskConfigItems(model, view.config))
     view.status_tasks = [""] * 25
     view.progress.tasks = Tasks(
         tuple([Task(j, model) for j in range(len(view.status_tasks))]),

--- a/src/examples/taskview/msgspec/task.py
+++ b/src/examples/taskview/msgspec/task.py
@@ -112,7 +112,7 @@ def update_task_status(*, view: ProgressView["Task"], parent_view: "TaskView") -
 
 def initialize_task(view: TaskView, main_view: "ExampleMainView", model: "Model") -> None:
     view.config.title = "Configuration"
-    form.initialize_form_view(view.config, TaskConfigItems(model, view.config))
+    form.initialize_form_view_items(view.config, TaskConfigItems(model, view.config))
     view.status_tasks = [""] * 25
     view.progress.tasks = Tasks(
         tuple([Task(j, model) for j in range(len(view.status_tasks))]),

--- a/src/examples/taskview/pydantic/task.py
+++ b/src/examples/taskview/pydantic/task.py
@@ -114,7 +114,7 @@ class TaskView(View):
 
 def initialize_task(view: TaskView, main_view: "ExampleMainView", model: "Model") -> None:
     view.config.title = "Configuration"
-    form.initialize_form_view(view.config, TaskConfigItems(model, view.config))
+    form.initialize_form_view_items(view.config, TaskConfigItems(model, view.config))
     view.status_tasks = [""] * 25
     view.progress.tasks = Tasks(
         tuple([Task(j, model) for j in range(len(view.status_tasks))]),

--- a/src/examples/vtkview/example.py
+++ b/src/examples/vtkview/example.py
@@ -203,7 +203,7 @@ def display_informations(*, view: VTKView, parent_view: VTKExampleView) -> None:
 def initialize_vtk_example(view: VTKExampleView, model: "Model") -> None:
     """Initialize the vtk view."""
     # configuration
-    form.initialize_form_view(
+    form.initialize_form_view_items(
         view.configuration, VTKConfigFormItems(model, view.configuration)
     )
     view.configuration.title = "Configuration"

--- a/tests/test_asyncview/conftest.py
+++ b/tests/test_asyncview/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> AsyncViewApp:
 @pytest.fixture()
 def app(global_app: AsyncViewApp) -> AsyncViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_formview/conftest.py
+++ b/tests/test_formview/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> FormViewApp:
 @pytest.fixture()
 def app(global_app: FormViewApp) -> FormViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_formview/test_applypipeview.py
+++ b/tests/test_formview/test_applypipeview.py
@@ -1,8 +1,9 @@
-from pathlib import Path
 from examples.formview.app import FormViewApp
 from examples.formview.pipeform import EdgeType
 
 import pytest
+
+from pathlib import Path
 
 
 @pytest.fixture()

--- a/tests/test_formview/test_applypipeview.py
+++ b/tests/test_formview/test_applypipeview.py
@@ -68,12 +68,17 @@ def test_update_visibility_with_incorrect_data(
     app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model],
 ) -> None:
     view, _, model = app_apply_pipe
+    assert view.items is not None
+    assert view.items.is_visible("chamfer") is False
+    assert view.chamfer.is_visible is False
     view.main.radius.field_view.value = 500
     view.main.radius.field_view.editing_finished()
     assert model.apply_pipe_query.get_edge_type() == EdgeType.Normal
     assert view.edge_type.field_view.current_index == 0
+    assert view.items.is_visible("chamfer") is False
     assert view.chamfer.is_visible is False
     view.edge_type.field_view.current_index = 1
     view.edge_type.field_view.current_index_changed()
+    assert view.items.is_enabled("chamfer") is True
     assert view.chamfer.is_visible is True
     assert model.apply_pipe_query.get_edge_type() == EdgeType.Normal

--- a/tests/test_formview/test_applypipeview.py
+++ b/tests/test_formview/test_applypipeview.py
@@ -1,45 +1,41 @@
-from examples.formview.app import FormViewApp, Model
-from examples.formview.example import ExampleMainView
-from examples.formview.pipeapplyform import PipeApplyFormView
+from examples.formview.app import FormViewApp
 from examples.formview.pipeform import EdgeType
 
 import pytest
 
-from typing import Tuple
-
 
 @pytest.fixture()
-def app_apply_pipe(app: FormViewApp) -> Tuple[PipeApplyFormView, ExampleMainView, Model]:
+def app_apply_pipe(app: FormViewApp) -> FormViewApp:
     app.main_view.toolbar.navigation.pipe.is_checked = False
     app.main_view.toolbar.navigation.apply_pipe.is_checked = True
     app.main_view.toolbar.navigation.toggled()
     assert app.main_view.pipe_view.is_visible is False
     assert app.main_view.apply_pipe_view.is_visible is True
-    return app.main_view.apply_pipe_view, app.main_view, app.model
+    return app
 
 
-def test_unmodify_db_before_apply(
-    app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model],
-) -> None:
-    view, _, model = app_apply_pipe
+def test_unmodify_db_before_apply(app_apply_pipe: FormViewApp) -> None:
+    view, model = app_apply_pipe.main_view.apply_pipe_view, app_apply_pipe.model
     assert model.apply_pipe_query.get_main_radius() == 80
     view.main.radius.field_view.value = 200
     view.main.radius.field_view.editing_finished()
     assert model.apply_pipe_query.get_main_radius() == 80
 
 
-def test_apply(app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model]) -> None:
-    view, _, model = app_apply_pipe
+def test_apply(app_apply_pipe: FormViewApp) -> None:
+    view, model = app_apply_pipe.main_view.apply_pipe_view, app_apply_pipe.model
     assert model.apply_pipe_query.get_main_radius() == 80
     view.main.radius.field_view.value = 75
     view.apply_clicked()
     assert model.apply_pipe_query.get_main_radius() == 75
 
 
-def test_open_file_without_apply(
-    app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model],
-) -> None:
-    view, main_view, model = app_apply_pipe
+def test_open_file_without_apply(app_apply_pipe: FormViewApp) -> None:
+    view, main_view, model = (
+        app_apply_pipe.main_view.apply_pipe_view,
+        app_apply_pipe.main_view,
+        app_apply_pipe.model,
+    )
     assert view.export.is_visible is True
     assert model.apply_pipe_query.get_export_path() is None
     assert view.export.field_view.text == ""
@@ -49,10 +45,8 @@ def test_open_file_without_apply(
     assert model.apply_pipe_query.get_export_path() is None
 
 
-def test_update_visibility_without_apply(
-    app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model],
-) -> None:
-    view, _, model = app_apply_pipe
+def test_update_visibility_without_apply(app_apply_pipe: FormViewApp) -> None:
+    view, model = app_apply_pipe.main_view.apply_pipe_view, app_apply_pipe.model
     assert model.apply_pipe_query.get_name() != ""
     assert view.name.field_view.text != ""
     assert model.apply_pipe_query.get_edge_type() == EdgeType.Normal
@@ -64,10 +58,8 @@ def test_update_visibility_without_apply(
     assert model.apply_pipe_query.get_edge_type() == EdgeType.Normal
 
 
-def test_update_visibility_with_incorrect_data(
-    app_apply_pipe: Tuple[PipeApplyFormView, ExampleMainView, Model],
-) -> None:
-    view, _, model = app_apply_pipe
+def test_update_visibility_with_incorrect_data(app_apply_pipe: FormViewApp) -> None:
+    view, model = app_apply_pipe.main_view.apply_pipe_view, app_apply_pipe.model
     assert view.items is not None
     assert view.items.is_visible("chamfer") is False
     assert view.chamfer.is_visible is False

--- a/tests/test_linkedtablefigureview/conftest.py
+++ b/tests/test_linkedtablefigureview/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> LinkedTableFigureViewApp:
 @pytest.fixture()
 def app(global_app: LinkedTableFigureViewApp) -> LinkedTableFigureViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_linkedtableview_sqlalchemy/conftest.py
+++ b/tests/test_linkedtableview_sqlalchemy/conftest.py
@@ -24,8 +24,6 @@ def global_app() -> LinkedTableViewApp:
 @pytest.fixture()
 def app(global_app: LinkedTableViewApp) -> LinkedTableViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_linkedtableview_sqlite/conftest.py
+++ b/tests/test_linkedtableview_sqlite/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> LinkedTableViewApp:
 @pytest.fixture()
 def app(global_app: LinkedTableViewApp) -> LinkedTableViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_mainview/conftest.py
+++ b/tests/test_mainview/conftest.py
@@ -16,7 +16,7 @@ def global_app() -> MainViewApp:
 @pytest.fixture()
 def app(global_app: MainViewApp) -> MainViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
     # back to the initial state of the view
     global_app.initialize()

--- a/tests/test_multipleviews/conftest.py
+++ b/tests/test_multipleviews/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> MultipleViewsApp:
 @pytest.fixture()
 def app(global_app: MultipleViewsApp) -> MultipleViewsApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_salomeview/conftest.py
+++ b/tests/test_salomeview/conftest.py
@@ -29,7 +29,7 @@ if is_salome_running():
         for module in global_app.modules:
             assert isinstance(module, (Module1App, Module2App))
             module.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-            # back to the initial state of the model
+            # back to the initial state of the app
             module.main_view.menu.file.new.triggered()
             # back to the initial state of the view
             module.initialize()

--- a/tests/test_simpletableview/conftest.py
+++ b/tests/test_simpletableview/conftest.py
@@ -17,8 +17,6 @@ def global_app() -> SimpleTableViewApp:
 def app(global_app: SimpleTableViewApp) -> SimpleTableViewApp:
     global_app.model.is_debug = False
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_tableview/conftest.py
+++ b/tests/test_tableview/conftest.py
@@ -17,8 +17,6 @@ def global_app() -> TableViewApp:
 def app(global_app: TableViewApp) -> TableViewApp:
     global_app.model.is_debug = False
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_taskview_mashumaro/conftest.py
+++ b/tests/test_taskview_mashumaro/conftest.py
@@ -15,8 +15,6 @@ def global_app() -> MashumaroTaskViewApp:
 @pytest.fixture()
 def app(global_app: MashumaroTaskViewApp) -> MashumaroTaskViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_taskview_msgspec/conftest.py
+++ b/tests/test_taskview_msgspec/conftest.py
@@ -25,8 +25,6 @@ if not sys.version_info < (3, 8):
         global_app: MsgspecTaskViewApp,
     ) -> MsgspecTaskViewApp:
         global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-        # back to the initial state of the model
+        # back to the initial state of the app
         global_app.main_view.menu.file.new.triggered()
-        # back to the initial state of the view
-        global_app.initialize()
         return global_app

--- a/tests/test_taskview_pydantic/conftest.py
+++ b/tests/test_taskview_pydantic/conftest.py
@@ -15,8 +15,6 @@ def global_app() -> PydanticTaskViewApp:
 @pytest.fixture()
 def app(global_app: PydanticTaskViewApp) -> PydanticTaskViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_treeview/conftest.py
+++ b/tests/test_treeview/conftest.py
@@ -16,8 +16,6 @@ def global_app() -> TreeViewApp:
 @pytest.fixture()
 def app(global_app: TreeViewApp) -> TreeViewApp:
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app

--- a/tests/test_vtkview/conftest.py
+++ b/tests/test_vtkview/conftest.py
@@ -17,8 +17,6 @@ def global_app() -> VTKViewApp:
 def app(global_app: VTKViewApp) -> VTKViewApp:
     global_app.model.is_debug = False
     global_app.main_view.message_view.run = lambda: True  # type: ignore[method-assign]
-    # back to the initial state of the model
+    # back to the initial state of the app
     global_app.main_view.menu.file.new.triggered()
-    # back to the initial state of the view
-    global_app.initialize()
     return global_app


### PR DESCRIPTION
- Remove maestro from the dependencies
- Add app to the default kwargs of a callback
- Add log_signals as an argument to the method run of a QtBaseApp to display the logs in the tests
- Add new_study to event driven app to disconnect/initialize/connect in addition to reset the model and use it when using the new action
- Correct the 'update all' function to avoid messing with the visibilities
- Add the creation of tables when opening an sqlite store (if there is an error here it is transformed into a warning). The idea is to facilitate the update of the sqlite database.
- Add a test for the saving/opening of a study